### PR TITLE
es-mx.json translate new strings

### DIFF
--- a/languages/es-mx.json
+++ b/languages/es-mx.json
@@ -126,6 +126,6 @@
   "Become a Patron": "Conviertete en Patreon",
   "Buy me a Coffee": "Invítame a un Café",
   "Report issues": "Reportar errores",
-  "#####Duplicates": "missing_translation",
-  "#####Dev Tools": "missing_translation"
+  "Duplicates": "Duplicados",
+  "Dev Tools": "Dev Tools"
 }


### PR DESCRIPTION
"Dev tools" is translated as "Herramientas de desarrollo" but the result is too long a phrase so it is decided not to translate it.